### PR TITLE
Rename pivot variables, move tableWeights

### DIFF
--- a/fiboFractais.pine
+++ b/fiboFractais.pine
@@ -69,6 +69,7 @@ var float lastMaxWeight = 0.0
 // Variáveis de “replay” de swings
 var int[]   swingBars   = array.new_int()  // armazena bar_index de cada swing detectado
 var int     swingsCount = 0                // contador de swings detectados
+var table tableWeights = table.new(position.top_left, 5, levelsCount + 1, bgcolor=color.new(color.black, 65), frame_color=color.rgb(78, 82, 94))  // tabela auxiliar de "weight"
 
 // ==================================================================
 // 4. TABELA DE STATUS (PARÂMETROS)
@@ -131,13 +132,13 @@ addFractal(_price) =>
 // ==================================================================
 // 7. COLETA DE FRACTAIS H1 (pivot high/low)
 // ==================================================================
-ph = request.security(syminfo.tickerid, "60", ta.pivothigh(high, n, n))
-pl = request.security(syminfo.tickerid, "60", ta.pivotlow(low, n, n))
+pivotHighH1 = request.security(syminfo.tickerid, "60", ta.pivothigh(high, n, n))
+pivotLowH1 = request.security(syminfo.tickerid, "60", ta.pivotlow(low, n, n))
 
-if not na(ph)
-    addFractal(ph)
-if not na(pl)
-    addFractal(pl)
+if not na(pivotHighH1)
+    addFractal(pivotHighH1)
+if not na(pivotLowH1)
+    addFractal(pivotLowH1)
 
 // ==================================================================
 // 8. CONTAGEM DE TOQUES DE FRACTAL NO TF H1 CONFIRMADO
@@ -153,18 +154,18 @@ if timeframe.isminutes and timeframe.multiplier == 60 and barstate.isconfirmed a
 // 9. PLOTAGEM DOS PONTOS DE FRACTAL (APENAS EM TF = H1)
 // ==================================================================
 if showFractalPoints
-    // apenas plota quando ph/pl corresponde a um dos últimos N valores registrados
-    if not na(ph)
+    // apenas plota quando pivotHighH1/pivotLowH1 corresponde a um dos últimos N valores registrados
+    if not na(pivotHighH1)
         float offsetTicksHigh = syminfo.mintick * 10
         int tph = request.security(syminfo.tickerid, "60", time[n])
-        label lb = label.new( x = tph, y = ph + offsetTicksHigh, text = "▲", xloc = xloc.bar_time, yloc = yloc.price, color = color.new(color.green, 0), textcolor = color.white, size = size.tiny)
+        label lb = label.new( x = tph, y = pivotHighH1 + offsetTicksHigh, text = "▲", xloc = xloc.bar_time, yloc = yloc.price, color = color.new(color.green, 0), textcolor = color.white, size = size.tiny)
         array.push(fractalPointLabels, lb)
         if array.size(fractalPointLabels) > maxFractalsToCheck
             label.delete(array.shift(fractalPointLabels))
-    if not na(pl)
+    if not na(pivotLowH1)
         float offsetTicksLow = syminfo.mintick * 10
         int tpl = request.security(syminfo.tickerid, "60", time[n])
-        label lb2 = label.new( x = tpl, y = pl - offsetTicksLow, text = "▼", xloc = xloc.bar_time, yloc = yloc.price, color = color.new(color.red, 0), textcolor = color.white, size = size.tiny)
+        label lb2 = label.new( x = tpl, y = pivotLowH1 - offsetTicksLow, text = "▼", xloc = xloc.bar_time, yloc = yloc.price, color = color.new(color.red, 0), textcolor = color.white, size = size.tiny)
         array.push(fractalPointLabels, lb2)
         if array.size(fractalPointLabels) > maxFractalsToCheck
             label.delete(array.shift(fractalPointLabels))
@@ -174,17 +175,17 @@ if showFractalPoints
 float prevHigh = lastHigh[1]
 float prevLow  = lastLow[1]
 
-if not na(ph)
-    if ph != prevHigh
+if not na(pivotHighH1)
+    if pivotHighH1 != prevHigh
         swingsCount += 1
         array.push(swingBars, bar_index)
-    lastHigh := ph
+    lastHigh := pivotHighH1
 
-if not na(pl)
-    if pl != prevLow
+if not na(pivotLowH1)
+    if pivotLowH1 != prevLow
         swingsCount += 1
         array.push(swingBars, bar_index)
-    lastLow := pl
+    lastLow := pivotLowH1
 
 bool doAutoHide = autoHideLow and timeframe.isminutes and timeframe.multiplier <= tfHideThresh
 int  currentSwingIdx = swingsCount > 0 ? swingsCount - 1 : 0
@@ -436,7 +437,8 @@ if not na(lastHigh) and not na(lastLow)
 // ==================================================================
 // 13. TABELA AUXILIAR DE “PROVA DE WEIGHT” (Top N / Z-score / Incluído?)
 // ==================================================================
-var table tableWeights = table.new(position.top_left, 5, levelsCount + 1, bgcolor=color.new(color.black, 65), frame_color=color.rgb(78, 82, 94))
+// tableWeights é declarado no bloco de variáveis persistentes
+
 
 if barstate.islast
     // Cabeçalhos


### PR DESCRIPTION
## Summary
- rename pivot variables to `pivotHighH1` and `pivotLowH1`
- relocate `tableWeights` creation to the early persistent vars block
- update comments referencing old variable names

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6843c35f794883269166a0470374d05f